### PR TITLE
Allow arguments to be passed to Lintly

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ jobs:
           failIf: new
           # Additional arguments to pass to flake8, default "." (current directory)
           args: "--ignore=E121,E123 ."
+          # Additional arguments to pass to lintly, default empty.
+          lintlyargs: "--no-request-changes"
 ```
 
 Now each PR created will be linted with Flake8. If there are any violations then Lintly will comment on the PR using the `github-actions` bot user.

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Args to pass to the flake8 executable
     required: false
     default: "."
+  lintlyargs:
+    description: Args to pass to the lintly executable
+    required: false 
+    default: ""
 
 runs:
   using: docker

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,4 +5,4 @@ if [[ $# -ne 0 ]]; then
     args="$@"
 fi
 
-flake8 ${args} | lintly --api-key $INPUT_TOKEN --fail-on $INPUT_FAILIF --log --no-post-status
+flake8 ${args} | lintly --api-key $INPUT_TOKEN --fail-on $INPUT_FAILIF --log --no-post-status $INPUT_LINTLYARGS


### PR DESCRIPTION
This PR allows optional parameters to be passed directly to Lintly, enabling the use of features like the --no-request-changes flag that may be desirable for this action.