### PR TITLE
Fix failing import from "markupsafe"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL "homepage"="https://github.com/grantmcconnaughey/lintly-flake8-github-acti
 LABEL "maintainer"="Grant McConnaughey <grantmcconnaughey@gmail.com>"
 
 RUN pip install --upgrade pip
+RUN pip install markupsafe==2.0.1
 RUN pip install flake8
 RUN pip install lintly
 


### PR DESCRIPTION
Force version 2.0.1 from "markupsafe" to avoid the error. I am using the solution outlined in a similar [issue](https://github.com/aws/aws-sam-cli/issues/3661#issuecomment-1044340547), but there may be better solutions.

Error trace:
```
Traceback (most recent call last):
  File "/usr/local/bin/lintly", line 5, in <module>
    from lintly.cli import main
  File "/usr/local/lib/python3.9/site-packages/lintly/cli.py", line 7, in <module>
    from .builds import LintlyBuild
  File "/usr/local/lib/python3.9/site-packages/lintly/builds.py", line 14, in <module>
    from .backends.github import GitHubBackend
  File "/usr/local/lib/python3.9/site-packages/lintly/backends/__init__.py", line 1, in <module>
    from .github import GitHubBackend  # noqa
  File "/usr/local/lib/python3.9/site-packages/lintly/backends/github.py", line 11, in <module>
    from lintly.formatters import (
  File "/usr/local/lib/python3.9/site-packages/lintly/formatters.py", line 6, in <module>
    from jinja2 import Environment, FileSystemLoader
  File "/usr/local/lib/python3.9/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/usr/local/lib/python3.9/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/usr/local/lib/python3.9/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.9/site-packages/markupsafe/__init__.py)
```